### PR TITLE
Change way of publish data on queue

### DIFF
--- a/infosystem/queue.py
+++ b/infosystem/queue.py
@@ -1,8 +1,6 @@
 import flask
-from typing import Any
 from pika import BlockingConnection, PlainCredentials, \
     ConnectionParameters, BasicProperties
-from infosystem.celery import celery, decide_on_run
 
 
 class RabbitMQ:
@@ -27,43 +25,29 @@ class RabbitMQ:
 
 class ProducerQueue:
 
-    def __init__(self, exchange, exchange_type):
+    def __init__(self):
         rabbitMQ = RabbitMQ()
         self.connection = rabbitMQ.connect()
-        self.exchange = exchange
         self.channel = self.connection.channel()
-        self.channel.exchange_declare(
-            exchange=exchange, exchange_type=exchange_type, durable=True)
 
-    def publish(self, routing_key):
-        body = ""
-        self.channel.basic_publish(
-            exchange=self.exchange, routing_key=routing_key, body=body)
-        self.close()
+    def publish(self, exchange, routing_key, body, properties=None):
+        self.channel.basic_publish(exchange=exchange,
+                                   routing_key=routing_key,
+                                   body=body,
+                                   properties=properties)
 
-    def publish_with_body(self, routing_key, body):
-        self.channel.basic_publish(
-            exchange=self.exchange, routing_key=routing_key, body=body)
-        self.close()
+    def publish_with_priority(self, exchange, routing_key, body,
+                              type, priority):
+        properties = BasicProperties(type=type, priority=priority)
+        self.channel.basic_publish(exchange=exchange,
+                                   routing_key=routing_key,
+                                   body=body,
+                                   properties=properties)
 
-    def publish_body_priority(self, routing_key, body, priority):
-        properties = BasicProperties(priority=priority, type=self.exchange)
-        self.channel.basic_publish(
-            exchange=self.exchange, routing_key=routing_key, body=body,
-            properties=properties)
+    def run(self, fn, *args):
+        fn(self, *args)
         self.close()
 
     def close(self):
         self.channel.close()
         self.connection.close()
-
-
-@decide_on_run
-@celery.task
-def publish_body_priority(exchange: str,
-                          priority: int,
-                          body: Any,
-                          routing_key: str = '',
-                          type: str = 'topic') -> None:
-    publish = ProducerQueue(exchange, type)
-    publish.publish_body_priority(routing_key, body, priority)


### PR DESCRIPTION
- Not declare the exchange before publish.
Obs :assume that exchange is already created

- Allow publish more than once on same connection

resolve #113 