### PR TITLE
Feature/118 domain settings

### DIFF
--- a/infosystem/resources.py
+++ b/infosystem/resources.py
@@ -28,8 +28,7 @@ SYSADMIN_RESOURCES = [
     ('/applications/<id>/roles', ['GET']),
 
     ('/domains/<id>', ['PUT', 'GET']),
-    ('/domains/<id>/settings', ['POST']),
-    ('/domains/<id1>/settings/<id2>', ['PUT', 'DELETE']),
+    ('/domains/<id>/settings', ['POST', 'PUT', 'DELETE']),
     ('/domains/<id>/logo', ['PUT', 'DELETE']),
 
     ('/capabilities', ['GET']),
@@ -73,6 +72,7 @@ USER_RESOURCES = [
     ('/tokens/<id>', ['GET', 'DELETE']),
     ('/applications/<id>', ['GET']),
     ('/domains/<id>', ['GET']),
+    ('/domains/<id>/settings', ['GET']),
     ('/images/<id>', ['GET']),
 
     ('/users/<id>', ['GET', 'PUT']),

--- a/infosystem/subsystem/domain/controller.py
+++ b/infosystem/subsystem/domain/controller.py
@@ -24,7 +24,9 @@ class Controller(controller.Controller):
         try:
             name = self._get_name_in_args()
             domain = self.manager.domain_by_name(domain_name=name)
-            response = {self.resource_wrap: domain.to_dict()}
+            domain_dict = domain.to_dict()
+            domain_dict.pop('settings')
+            response = {self.resource_wrap: domain_dict}
             return flask.Response(response=json.dumps(response, default=str),
                                   status=200,
                                   mimetype="application/json")
@@ -132,12 +134,12 @@ class Controller(controller.Controller):
                               status=204,
                               mimetype="application/json")
 
-    def create_setting(self, id):
+    def create_settings(self, id):
         try:
             data = flask.request.get_json()
 
-            setting = self.manager.create_setting(id=id, **data)
-            response = {'setting': setting.to_dict()}
+            settings = self.manager.create_settings(id=id, **data)
+            response = {'settings': settings}
 
             return flask.Response(response=utils.to_json(response),
                                   status=201,
@@ -146,16 +148,12 @@ class Controller(controller.Controller):
             return flask.Response(response=exc.message,
                                   status=exc.status)
 
-    def update_setting(self, id1, id2):
-        domain_id = id1
-        setting_id = id2
+    def update_settings(self, id):
         try:
             data = flask.request.get_json()
 
-            setting = self.manager.update_setting(id=domain_id,
-                                                  setting_id=setting_id,
-                                                  **data)
-            response = {'setting': setting.to_dict()}
+            settings = self.manager.update_settings(id=id, **data)
+            response = {'settings': settings}
 
             return flask.Response(response=utils.to_json(response),
                                   status=200,
@@ -164,13 +162,32 @@ class Controller(controller.Controller):
             return flask.Response(response=exc.message,
                                   status=exc.status)
 
-    def remove_setting(self, id1, id2):
-        domain_id = id1
-        setting_id = id2
+    def _get_keys_from_args(self):
+        keys = flask.request.args.get('keys')
+        return list(filter(None, keys.split(',')))
+
+    def remove_settings(self, id):
         try:
-            setting = self.manager.remove_setting(id=domain_id,
-                                                  setting_id=setting_id)
-            response = {'setting': setting.to_dict()}
+            keys = self._get_keys_from_args()
+            kwargs = {'keys': keys}
+
+            settings = self.manager.remove_settings(id=id, **kwargs)
+            response = {'settings': settings}
+
+            return flask.Response(response=utils.to_json(response),
+                                  status=200,
+                                  mimetype="application/json")
+        except exception.InfoSystemException as exc:
+            return flask.Response(response=exc.message,
+                                  status=exc.status)
+
+    def get_domain_settings_by_keys(self, id):
+        try:
+            keys = self._get_keys_from_args()
+            kwargs = {'keys': keys}
+
+            settings = self.manager.get_domain_settings_by_keys(id=id, **kwargs)
+            response = {'settings': settings}
 
             return flask.Response(response=utils.to_json(response),
                                   status=200,

--- a/infosystem/subsystem/domain/router.py
+++ b/infosystem/subsystem/domain/router.py
@@ -1,3 +1,4 @@
+from celery.app.utils import Settings
 from infosystem.common.subsystem import router
 
 
@@ -8,6 +9,7 @@ class Router(router.Router):
 
     @property
     def routes(self):
+        settings_endpoint = '/settings'
         return super().routes + [
             {
                 'action': 'Get Domain By Name',
@@ -50,24 +52,31 @@ class Router(router.Router):
                 'bypass': True
             },
             {
-                'action': 'Create a setting Domain',
+                'action': 'Create settings on Domain',
                 'method': 'POST',
-                'url': self.resource_url + '/settings',
-                'callback': self.controller.create_setting,
+                'url': self.resource_url + settings_endpoint,
+                'callback': self.controller.create_settings,
                 'bypass': False
             },
             {
-                'action': 'Update a setting Domain',
+                'action': 'Update settings on Domain',
                 'method': 'PUT',
-                'url': self.resource_enum_url + '/settings/<id2>',
-                'callback': self.controller.update_setting,
+                'url': self.resource_url + settings_endpoint,
+                'callback': self.controller.update_settings,
                 'bypass': False
             },
             {
-                'action': 'Remove a setting Domain',
+                'action': 'Remove settings from Domain',
                 'method': 'DELETE',
-                'url': self.resource_enum_url + '/settings/<id2>',
-                'callback': self.controller.remove_setting,
+                'url': self.resource_url + settings_endpoint,
+                'callback': self.controller.remove_settings,
+                'bypass': False
+            },
+            {
+                'action': 'Get settings by keys from Domain',
+                'method': 'GET',
+                'url': self.resource_url + settings_endpoint,
+                'callback': self.controller.get_domain_settings_by_keys,
                 'bypass': False
             }
         ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 apscheduler
 flask
 flask-sqlalchemy
+sqlalchemy-json
 flask-rbac
 gabbi
 pika

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,9 @@ from setuptools import setup, find_packages
 REQUIRED_PACKAGES = [
     'apscheduler',
     'flask',
-    'flask-sqlalchemy',
     'flask-rbac',
+    'flask-sqlalchemy',
+    'sqlalchemy-json',
     'gabbi',
     'pika',
     'sparkpost',


### PR DESCRIPTION
- Add attribute settings as json
- Change methods do operate on settings
- Remove DomainSetting
- Remove settings from get domain_by_name

- [GET]
  - `base_url/domains/domain_id/settings?keys=key1,key2`

- [POST]
  - `base_url/domains/domain_id/settings`

  If a setting already exists return error

  ```json
  {
      "example": "example_value"
  }
  ```

- [PUT]
  - `base_url/domains/domain_id/settings`

  If a setting not exists return error

  ```json
  {
      "example": "example_value"
  }
  ```

- [DELETE]
  - `base_url/domains/domain_id/settings?keys=key1,key2`

  return 200 and settings removed

resolve #118 
