### PR TITLE
Fix error 500 when keys not passed correctly

### DIFF
--- a/infosystem/subsystem/domain/controller.py
+++ b/infosystem/subsystem/domain/controller.py
@@ -164,6 +164,9 @@ class Controller(controller.Controller):
 
     def _get_keys_from_args(self):
         keys = flask.request.args.get('keys')
+        if not keys:
+            raise exception.BadRequest(
+                'ERRO! The keys parameter was not passed correctly')
         return list(filter(None, keys.split(',')))
 
     def remove_settings(self, id):


### PR DESCRIPTION
On GET or DELETE from /domains/domain_id/settings  if the keys parameter is not passed correctly the system would throw an exception 500.
Now return Bad Request