### PR TITLE
Remove migration as default

### DIFF
--- a/infosystem/__init__.py
+++ b/infosystem/__init__.py
@@ -65,7 +65,8 @@ class SystemFlask(flask.Flask):
 
     def init_database(self):
         database.db.init_app(self)
-        database.migrate.init_app(self, database.db)
+        with self.app_context():
+            database.db.create_all()
 
     def after_init_database(self):
         pass


### PR DESCRIPTION
Run create_all on database at start by default